### PR TITLE
Fix diff readability

### DIFF
--- a/neovim.lua
+++ b/neovim.lua
@@ -79,6 +79,11 @@ return {
         LspInlayHint = { fg = "#52494e", bg = "NONE" },
 
         ["@comment"] = { link = "Comment" },
+
+        -- Fix diff readability
+        DiffAdd = { fg = "#101010" },
+        DiffChange = { fg = "#ffffff" },
+        DiffDelete = { fg = "#ffffff" },
       },
     },
   },


### PR DESCRIPTION
Also applies to render-markdown.nvim

Before:
<img width="823" height="124" alt="before" src="https://github.com/user-attachments/assets/e7bfda71-2c23-4804-824c-d2e600d89748" />

After:
<img width="712" height="124" alt="after" src="https://github.com/user-attachments/assets/fe784625-a916-4016-825b-07f0c1b2f8e5" />
